### PR TITLE
Update CN translation

### DIFF
--- a/locale/zh-CN/all.cfg
+++ b/locale/zh-CN/all.cfg
@@ -80,6 +80,8 @@ raven-tech=渡鸦模组技术门槛
 heli-equipment-grid=直升机装备插槽
 non-combat-mode=非战斗模式
 inserter-immunity=忽略机械臂
+lock-surfaces-space-age=限制飞行器在某些星球使用
+experimental-features=启用实验性功能
 
 [mod-setting-description]
 aircraft-sound-setting=取消勾选即使用原版汽车音效.
@@ -90,3 +92,5 @@ raven-tech=渡鸦技术被置于高级空气动力学研究之后. 安装了Rave
 heli-equipment-grid=使武装直升机配备和空中炮艇相同的装备插槽. 安装了HelicoptersRevival模组的情况下生效.
 non-combat-mode=从科技树上禁用除货运飞机外的飞行器. (此选项每次保存不可逆!)
 inserter-immunity=使所有飞行器忽略机械臂搬运, 热能机械臂除外.
+lock-surfaces-space-age=限制飞行器在某些星球使用. 仅Space Age启用时生效.
+experimental-features=启用一些开发中的实验性功能. 不保证没有bug或者有什么实际功能.


### PR DESCRIPTION
add
[mod-setting-name]
lock-surfaces-space-age=Restrict Aircraft based on surface conditions experimental-features=Enable Experimental Features

[mod-setting-description]
lock-surfaces-space-age=Restricts aircraft based on surface conditions. Only relevant to Space Age. experimental-features=Enable features that are still in development. There is no guarantee that this option does anything.