### PR TITLE
Fix specific mod crash (check description)

### DIFF
--- a/Aircraft-space-age/prototypes/technologies-updates.lua
+++ b/Aircraft-space-age/prototypes/technologies-updates.lua
@@ -1,3 +1,3 @@
-if data.raw.technology["tungsten-processing"] then
+if mods["bobplates"] and data.raw.technology["tungsten-processing"] then
   bobmods.lib.tech.add_prerequisite ("flying-fortress", "tungsten-alloy-processing")
 end


### PR DESCRIPTION
If any mod adds technology named "tungsten-processing", Aircraft thinks that it's from the bobplates (which isn't anyways - in 2.0 it's "bob-tungsten-processing", but I didn't changed it here) and crashes due to missing prototypes.
This PR is just adding a check if it's actually bobplates, so it won't crash.